### PR TITLE
Support a custom project name prefix

### DIFF
--- a/terraform/gcp.tf
+++ b/terraform/gcp.tf
@@ -8,7 +8,7 @@ provider "google" {
 # Generate a random id for the project - GCP projects must have globally
 # unique names
 resource "random_id" "random" {
-  prefix      = "vault-"
+  prefix      = "${var.project_prefix}"
   byte_length = "8"
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -13,6 +13,11 @@ variable "project" {
   default = ""
 }
 
+variable "project_prefix" {
+  type    = "string"
+  default = "vault-"
+}
+
 variable "billing_account" {
   type = "string"
 }


### PR DESCRIPTION
Allow for alignment with project naming conventions inside an organization.