### PR TITLE
Cluster hardening additions

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -26,6 +26,11 @@ variable "instance_type" {
   default = "n1-standard-2"
 }
 
+variable "daily_maintenance_window" {
+  type    = "string"
+  default = "06:00"
+}
+
 variable "service_account_iam_roles" {
   type = "list"
 


### PR DESCRIPTION
Several items from the GCP CIS Benchmark hardening guide:
- Enable Network Policy support
- Disable Issuing of client certs
- Disable Basic Auth
- Enable a customizable maintenance window on the default node pool
- Add a label for "service = vault"
- Ensure the dashboard is not enabled