### PR TITLE
Optionally specify an existing project_id

### DIFF
--- a/terraform/gcp.tf
+++ b/terraform/gcp.tf
@@ -34,7 +34,7 @@ data "google_project" "vault" {
 # Obtain the project_id from either the newly created project resource or existing data project resource
 # One will be populated and the other will be null
 locals {
-  vault_project_id = "${join(",",data.google_project.vault.*.project_id)}${join(",",google_project.vault.*.project_id) }"
+  vault_project_id = "${element(concat(data.google_project.vault.*.project_id, google_project.vault.*.project_id),0)}"
 }
 
 # Create the vault service account

--- a/terraform/k8s.tf
+++ b/terraform/k8s.tf
@@ -119,6 +119,6 @@ output "root_token" {
 
 # Uncomment this if you want to decrypt the token yourself
 # output "root_token_decrypt_command" {
-#   value = "gsutil cat gs://${google_storage_bucket.vault.name}/root-token.enc | base64 --decode | gcloud kms decrypt --project ${google_project.vault.project_id} --location ${var.region} --keyring ${google_kms_key_ring.vault.name} --key ${google_kms_crypto_key.vault-init.name} --ciphertext-file - --plaintext-file -"
+#   value = "gsutil cat gs://${google_storage_bucket.vault.name}/root-token.enc | base64 --decode | gcloud kms decrypt --project ${local.vault_project_id} --location ${var.region} --keyring ${google_kms_key_ring.vault.name} --key ${google_kms_crypto_key.vault-init.name} --ciphertext-file - --plaintext-file -"
 # }
 


### PR DESCRIPTION
If the var `project` is not empty, use that value as the project to deploy into.  Otherwise, the default of `""` will allow the existing behavior to remain where a new project is dynamically created.  This supports the use case of a user without permissions to create/destroy projects in an organization but has `Owner` rights to an existing project.