### PR TITLE
Specify the Namespace Explicitly

### DIFF
--- a/terraform/k8s.tf
+++ b/terraform/k8s.tf
@@ -67,7 +67,7 @@ resource "null_resource" "apply" {
 gcloud container clusters get-credentials "${google_container_cluster.vault.name}" --region="${google_container_cluster.vault.region}" --project="${google_container_cluster.vault.project}"
 
 CONTEXT="gke_${google_container_cluster.vault.project}_${google_container_cluster.vault.region}_${google_container_cluster.vault.name}"
-echo '${data.template_file.vault.rendered}' | kubectl apply --context="$CONTEXT" -f -
+echo '${data.template_file.vault.rendered}' | kubectl apply -n default --context="$CONTEXT" -f -
 EOF
   }
 }
@@ -78,7 +78,7 @@ resource "null_resource" "wait-for-finish" {
     command = <<EOF
 for i in $(seq -s " " 1 15); do
   sleep $i
-  if [ $(kubectl get pod | grep vault | wc -l) -eq ${var.num_vault_pods} ]; then
+  if [ $(kubectl get pod -n default | grep vault | wc -l) -eq ${var.num_vault_pods} ]; then
     exit 0
   fi
 done


### PR DESCRIPTION
Seemingly pedantic, it actually would really help us out having this explicit so we can run this terraform from inside CI pods in a different namespace than "default".  `kubectl` seems to pick up on the `/var/run/secrets/kubernetes.io/serviceaccount/namespace` from the pod if omitted on the command line.  In our case, this means the vault pods are attempted to be put in the `jenkins` namespace which doesn't exist.  As an interim workaround, we run the Jenkins worker pod in our `default` namespace so that `kubectl` aligns, but that means other less optimal configuration maintenance has to happen.  If this gets merged, then our CI jobs can be greatly simplified. Thanks!