### PR TITLE
Support limiting IP addresses able to connect to Vault

### DIFF
--- a/terraform/k8s.tf
+++ b/terraform/k8s.tf
@@ -1,4 +1,4 @@
-# Query the client configuration for our current service account, which shoudl
+# Query the client configuration for our current service account, which should
 # have permission to talk to the GKE cluster since it created it.
 data "google_client_config" "current" {}
 
@@ -35,9 +35,10 @@ resource "kubernetes_service" "vault-lb" {
   }
 
   spec {
-    type                    = "LoadBalancer"
-    load_balancer_ip        = google_compute_address.vault.address
-    external_traffic_policy = "Local"
+    type                        = "LoadBalancer"
+    load_balancer_ip            = google_compute_address.vault.address
+    load_balancer_source_ranges = var.vault_source_ranges
+    external_traffic_policy     = "Local"
 
     selector = {
       app = "vault"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -168,7 +168,15 @@ variable "kubernetes_master_authorized_networks" {
     },
   ]
 
-  description = "List of CIDR blocks to allow access to the master's API endpoint. This is specified as a slice of objects, where each object has a display_name and cidr_block attribute. The default behavior is to allow anyone (0.0.0.0/0) access to the endpoint. You should restrict access to external IPs that need to access the cluster."
+  description = "List of CIDR blocks to allow access to the Kubernetes master's API endpoint. This is specified as a slice of objects, where each object has a display_name and cidr_block attribute. The default behavior is to allow anyone (0.0.0.0/0) access to the endpoint. You should restrict access to external IPs that need to access the Kubernetes cluster."
+}
+
+# This is an option used by the kubernetes provider, but is part of the Vault
+# security posture.
+variable "vault_source_ranges" {
+  type        = list(string)
+  default     = [ "0.0.0.0/0" ]
+  description = "List of addresses or CIDR blocks which are allowed to connect to the Vault IP address. The default behavior is to allow anyone (0.0.0.0/0) access. You should restrict access to external IPs that need to access the Vault cluster."
 }
 
 #


### PR DESCRIPTION
This allows you to control what hosts can connect to the Vault service itself. `/32` ranges are useful for specifying individual hosts, such as a GCP NAT's external IP.