### PR TITLE
Fix name of Terraform output

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ please follow Kelsey's repository instead.
     # $ cd terraform/
 
     $ export VAULT_ADDR="https://$(terraform output address)"
-    $ export VAULT_TOKEN="$(terraform output root_token)"
+    $ export VAULT_TOKEN="$(terraform output root_token_decrypt_command)"
     $ export VAULT_CAPATH="$(cd ../ && pwd)/tls/ca.pem"
     ```
 


### PR DESCRIPTION
The current command fails with `root_token`. The output was renamed to `root_token_decrypt_command` in https://github.com/sethvargo/vault-on-gke/commit/0391b367743466ef924044c54d89e8a98b71633d.