### PR TITLE
Uses result of the gsutil command

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ please follow Kelsey's repository instead.
     # $ cd terraform/
 
     $ export VAULT_ADDR="https://$(terraform output address)"
-    $ export VAULT_TOKEN="$(terraform output root_token_decrypt_command)"
+    $ export VAULT_TOKEN="$(eval `terraform output root_token_decrypt_command`)"
     $ export VAULT_CAPATH="$(cd ../ && pwd)/tls/ca.pem"
     ```
 


### PR DESCRIPTION
I used backticks because it was more aesthetically pleasing than nested $()

Tested in Google CloudShell.