### PR TITLE
Replaced GKE version configuration with release channel.

### DIFF
--- a/terraform/gcp.tf
+++ b/terraform/gcp.tf
@@ -225,12 +225,6 @@ resource "google_compute_router_nat" "vault-nat" {
   }
 }
 
-# Get latest cluster version
-data "google_container_engine_versions" "versions" {
-  project  = data.google_project.vault.project_id
-  location = var.region
-}
-
 # Create the GKE cluster
 resource "google_container_cluster" "vault" {
   provider = google-beta
@@ -244,8 +238,9 @@ resource "google_container_cluster" "vault" {
 
   initial_node_count = var.kubernetes_nodes_per_zone
 
-  min_master_version = data.google_container_engine_versions.versions.latest_master_version
-  node_version       = data.google_container_engine_versions.versions.latest_master_version
+  release_channel {
+    channel = var.kubernetes_release_channel
+  }
 
   logging_service    = var.kubernetes_logging_service
   monitoring_service = var.kubernetes_monitoring_service

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -171,6 +171,11 @@ variable "kubernetes_master_authorized_networks" {
   description = "List of CIDR blocks to allow access to the Kubernetes master's API endpoint. This is specified as a slice of objects, where each object has a display_name and cidr_block attribute. The default behavior is to allow anyone (0.0.0.0/0) access to the endpoint. You should restrict access to external IPs that need to access the Kubernetes cluster."
 }
 
+variable "kubernetes_release_channel" {
+  type = string
+  default = "REGULAR"
+}
+
 # This is an option used by the kubernetes provider, but is part of the Vault
 # security posture.
 variable "vault_source_ranges" {


### PR DESCRIPTION
This replaces fetching explicit Kubernetes versions from GCP with support for GKE release channels.