### PR TITLE
Fix deprecated attribute

### DIFF
--- a/terraform/gcp.tf
+++ b/terraform/gcp.tf
@@ -72,7 +72,7 @@ resource "google_storage_bucket" "vault" {
   force_destroy = true
   storage_class = "MULTI_REGIONAL"
 
-  bucket_policy_only = true
+  uniform_bucket_level_access = true
 
   versioning {
     enabled = true

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -172,7 +172,7 @@ variable "kubernetes_master_authorized_networks" {
 }
 
 variable "kubernetes_release_channel" {
-  type = string
+  type    = string
   default = "REGULAR"
 }
 
@@ -180,7 +180,7 @@ variable "kubernetes_release_channel" {
 # security posture.
 variable "vault_source_ranges" {
   type        = list(string)
-  default     = [ "0.0.0.0/0" ]
+  default     = ["0.0.0.0/0"]
   description = "List of addresses or CIDR blocks which are allowed to connect to the Vault IP address. The default behavior is to allow anyone (0.0.0.0/0) access. You should restrict access to external IPs that need to access the Vault cluster."
 }
 


### PR DESCRIPTION
The bucket_policy_only is deprecated since it have been renamed by Google in favor of uniform_bucket_level_access.