### PR TITLE
fix/unexpected argument load_config_file and unsupported block type requests

### DIFF
--- a/terraform/k8s.tf
+++ b/terraform/k8s.tf
@@ -4,8 +4,7 @@ data "google_client_config" "current" {}
 
 # This file contains all the interactions with Kubernetes
 provider "kubernetes" {
-  load_config_file = false
-  host             = google_container_cluster.vault.endpoint
+  host = google_container_cluster.vault.endpoint
 
   cluster_ca_certificate = base64decode(
     google_container_cluster.vault.master_auth[0].cluster_ca_certificate,

--- a/terraform/k8s.tf
+++ b/terraform/k8s.tf
@@ -106,7 +106,7 @@ resource "kubernetes_stateful_set" "vault" {
           image_pull_policy = "IfNotPresent"
 
           resources {
-            requests {
+            requests = {
               cpu    = "100m"
               memory = "64Mi"
             }
@@ -164,7 +164,7 @@ resource "kubernetes_stateful_set" "vault" {
           }
 
           resources {
-            requests {
+            requests = {
               cpu    = "500m"
               memory = "256Mi"
             }


### PR DESCRIPTION
```
$- terraform14 plan

Error: Unsupported argument

  on k8s.tf line 7, in provider "kubernetes":
   7:   load_config_file = false

An argument named "load_config_file" is not expected here.
```

```
$- terraform14 plan

Error: Unsupported block type

  on k8s.tf line 109, in resource "kubernetes_stateful_set" "vault":
 109:             requests {

Blocks of type "requests" are not expected here. Did you mean to define
argument "requests"? If so, use the equals sign to assign it a value.
```