### PR TITLE
Fix for Vault-Init environment variables

### DIFF
--- a/terraform/k8s.tf
+++ b/terraform/k8s.tf
@@ -168,12 +168,12 @@ resource "kubernetes_stateful_set" "vault" {
           }
 
           env {
-            name  = "VAULT_SECRET_SHARES"
+            name  = "VAULT_RECOVERY_SHARES"
             value = var.vault_recovery_shares
           }
 
           env {
-            name  = "VAULT_SECRET_THRESHOLD"
+            name  = "VAULT_RECOVERY_THRESHOLD"
             value = var.vault_recovery_threshold
           }
         }


### PR DESCRIPTION
Currently no matter what you set for `vault_recovery_shares` or `vault_recovery_threshold` you will end up with only one recovery share generated. After looking at your other repo for vault-init I was able to fix this problem using the environment variables defined there.