### PR TITLE
Adapt scripts to avoid fields removed in provider v4.0.0

### DIFF
--- a/terraform/gcp.tf
+++ b/terraform/gcp.tf
@@ -276,7 +276,7 @@ resource "google_container_cluster" "vault" {
 
     # Protect node metadata
     workload_metadata_config {
-      node_metadata = "SECURE"
+      mode = "GCE_METADATA"
     }
   }
 
@@ -290,8 +290,6 @@ resource "google_container_cluster" "vault" {
 
   # Disable basic authentication and cert-based authentication.
   master_auth {
-    username = ""
-    password = ""
 
     client_certificate_config {
       issue_client_certificate = false

--- a/terraform/tls.tf
+++ b/terraform/tls.tf
@@ -6,7 +6,6 @@ resource "tls_private_key" "vault-ca" {
 }
 
 resource "tls_self_signed_cert" "vault-ca" {
-  key_algorithm   = tls_private_key.vault-ca.algorithm
   private_key_pem = tls_private_key.vault-ca.private_key_pem
 
   subject {
@@ -36,7 +35,6 @@ resource "tls_private_key" "vault" {
 
 # Create the request to sign the cert with our CA
 resource "tls_cert_request" "vault" {
-  key_algorithm   = tls_private_key.vault.algorithm
   private_key_pem = tls_private_key.vault.private_key_pem
 
   dns_names = [
@@ -59,7 +57,6 @@ resource "tls_cert_request" "vault" {
 resource "tls_locally_signed_cert" "vault" {
   cert_request_pem = tls_cert_request.vault.cert_request_pem
 
-  ca_key_algorithm   = tls_private_key.vault-ca.algorithm
   ca_private_key_pem = tls_private_key.vault-ca.private_key_pem
   ca_cert_pem        = tls_self_signed_cert.vault-ca.cert_pem
 


### PR DESCRIPTION
GCP terraform provide v4.0.0 removed several previously deprecated fields: 
- `google_container_cluster.workload_metadata_config.mode` is the new field instead of the removed `google_container_cluster.workload_metadata_config.node_metadata=SECURE`.
- google_container_cluster.master_auth: username/password unexpected. These were [deprecated](https://registry.terraform.io/providers/hashicorp/google/3.90.1/docs/resources/container_cluster#nested_master_auth) in GKE and removed in provider v4.0.0.


Certificate provider also switched easily inferred fields to readonly:
 - tls_self_signed_cert.key_algorithm 
 - tls_locally_signed_cert.ca_key_algorithm

Fixes #101.

